### PR TITLE
Jenkins: remove timestamp action

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+#!/usr/bin/env groovy
+
 pipeline {
   agent { label 'android-agent' }
 
@@ -8,6 +10,11 @@ pipeline {
     SLACK_COLOR_GOOD    = '#3EB991'
 
     PROJECT_NAME = 'Calabash screenshotTaker'
+  }
+
+  options {
+    disableConcurrentBuilds()
+    timeout(time: 30, unit: 'MINUTES')
   }
 
   stages {
@@ -47,11 +54,5 @@ pipeline {
       slackSend (color: "${env.SLACK_COLOR_GOOD}",
                  message: "${env.PROJECT_NAME} [${env.GIT_BRANCH}] #${env.BUILD_NUMBER} *Success* after ${currentBuild.durationString.replace('and counting', '')}(<${env.BUILD_URL}|Open>)")
     }
-  }
-
-  options {
-    disableConcurrentBuilds()
-    timeout(time: 30, unit: 'MINUTES')
-    timestamps()
   }
 }


### PR DESCRIPTION
### Motivation

The Jenkins instance has been reinstalled and the timestamper plugin was not installed.